### PR TITLE
power: Remove custom low power mode hint handling

### DIFF
--- a/power/power-8084.c
+++ b/power/power-8084.c
@@ -100,14 +100,6 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
 		return HINT_HANDLED;
 	}
 
-    if (hint == POWER_HINT_LOW_POWER) {
-        if (current_power_profile == PROFILE_POWER_SAVE) {
-            set_power_profile(PROFILE_BALANCED);
-        } else {
-            set_power_profile(PROFILE_POWER_SAVE);
-        }
-    }
-
 	// Skip other hints in custom power modes
 	if (current_power_profile != PROFILE_BALANCED) {
 		return HINT_HANDLED;

--- a/power/power-8226.c
+++ b/power/power-8226.c
@@ -97,14 +97,6 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LOW_POWER) {
-        if (current_power_profile == PROFILE_POWER_SAVE) {
-            set_power_profile(PROFILE_BALANCED);
-        } else {
-            set_power_profile(PROFILE_POWER_SAVE);
-        }
-    }
-
     // Skip other hints in custom power modes
     if (current_power_profile != PROFILE_BALANCED) {
         return HINT_HANDLED;

--- a/power/power-8610.c
+++ b/power/power-8610.c
@@ -95,14 +95,6 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LOW_POWER) {
-        if (current_power_profile == PROFILE_POWER_SAVE) {
-            set_power_profile(PROFILE_BALANCED);
-        } else {
-            set_power_profile(PROFILE_POWER_SAVE);
-        }
-    }
-
     // Skip other hints in custom power modes
     if (current_power_profile != PROFILE_BALANCED) {
         return HINT_HANDLED;

--- a/power/power-8916.c
+++ b/power/power-8916.c
@@ -382,14 +382,6 @@ int power_hint_override(struct power_module *module __unused, power_hint_t hint,
         set_power_profile(*(int32_t *)data);
     }
 
-    if (hint == POWER_HINT_LOW_POWER) {
-        if (current_power_profile == PROFILE_POWER_SAVE) {
-            set_power_profile(PROFILE_BALANCED);
-        } else {
-            set_power_profile(PROFILE_POWER_SAVE);
-        }
-    }
-
     // Skip other hints in custom power modes
     if (current_power_profile != PROFILE_BALANCED) {
         return HINT_HANDLED;

--- a/power/power-8960.c
+++ b/power/power-8960.c
@@ -140,14 +140,6 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LOW_POWER) {
-        if (current_power_profile == PROFILE_POWER_SAVE) {
-            set_power_profile(PROFILE_BALANCED);
-        } else {
-            set_power_profile(PROFILE_POWER_SAVE);
-        }
-    }
-
     // Skip other hints in custom power modes
     if (current_power_profile != PROFILE_BALANCED) {
         return HINT_HANDLED;

--- a/power/power-8974.c
+++ b/power/power-8974.c
@@ -114,14 +114,6 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
         return HINT_HANDLED;
     }
 
-    if (hint == POWER_HINT_LOW_POWER) {
-        if (current_power_profile == PROFILE_POWER_SAVE) {
-            set_power_profile(PROFILE_BALANCED);
-        } else {
-            set_power_profile(PROFILE_POWER_SAVE);
-        }
-    }
-
     // Skip other hints in high/low power modes
     if (current_power_profile == PROFILE_POWER_SAVE ||
             current_power_profile == PROFILE_HIGH_PERFORMANCE) {

--- a/power/power-8994.c
+++ b/power/power-8994.c
@@ -54,7 +54,6 @@ int get_number_of_profiles() {
 }
 
 static int current_power_profile = PROFILE_BALANCED;
-static int low_power_mode = 0;
 
 static void set_power_profile(int profile) {
 
@@ -169,19 +168,8 @@ static int process_video_encode_hint(void *metadata)
 int power_hint_override(__attribute__((unused)) struct power_module *module,
         power_hint_t hint, void *data)
 {
-    if (hint == POWER_HINT_SET_PROFILE && !low_power_mode) {
+    if (hint == POWER_HINT_SET_PROFILE) {
         set_power_profile(*(int32_t *)data);
-        return HINT_HANDLED;
-    }
-
-    if (hint == POWER_HINT_LOW_POWER) {
-        if (low_power_mode) {
-            set_power_profile(PROFILE_BALANCED);
-            low_power_mode = 0;
-        } else {
-            set_power_profile(PROFILE_POWER_SAVE);
-            low_power_mode = 1;
-        }
         return HINT_HANDLED;
     }
 


### PR DESCRIPTION
The PerformanceManager code now handles the setting of powersave
profile on low power mode, so this is redundant.

This implementation also doesn't remember the previous user selected
performance profile, instead only setting to balanced profile when
low power mode is turned off.

Change-Id: I5d65cd1e7b915e9a088523d2d62ae541b5bcd78c
